### PR TITLE
Remove AutonomousRiskFramework from packages list

### DIFF
--- a/install.jl
+++ b/install.jl
@@ -15,9 +15,6 @@ packages = [
 
     # [deps] RiskSimulator.jl
     PackageSpec(url=joinpath(@__DIR__, "RiskSimulator.jl")),
-
-    # [deps] AutonomousRiskFramework.jl
-    PackageSpec(url=joinpath(@__DIR__)),
 ]
 
 ci = haskey(ENV, "CI") && ENV["CI"] == "true"


### PR DESCRIPTION
It seems having AutonomousRiskFramework.jl itself in the list of packages to develop makes it not possible to run the script within an environment:
  ERROR: package `AutonomousRiskFramework [f30adb48]` has the same name or UUID as the active project
With it removed, the script seems to work fine i.e., after you do `]activate .`

Can we simply remove it as I've done?